### PR TITLE
make it compatible with new hashing

### DIFF
--- a/src/iterutils.nim
+++ b/src/iterutils.nim
@@ -318,4 +318,7 @@ when isMainModule:
     var s = newSeq[int]()
     for i in myiteropt(toClosure(values(d))): s.add(i)
     for i in myiteropt(toClosure(2..10)): s.add(i)
-    assert s == @[4, 5, 6, 4, 5, 6, 4, 5, 6, 2, 3, 4, 5, 6, 7, 8, 9, 10, 2, 3, 4, 5, 6, 7, 8, 9, 10, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    when NimVersion < "1.0.2":
+      assert s == @[4, 5, 6, 4, 5, 6, 4, 5, 6, 2, 3, 4, 5, 6, 7, 8, 9, 10, 2, 3, 4, 5, 6, 7, 8, 9, 10, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    else:
+      assert s == @[6, 5, 4, 6, 5, 4, 6, 5, 4, 2, 3, 4, 5, 6, 7, 8, 9, 10, 2, 3, 4, 5, 6, 7, 8, 9, 10, 2, 3, 4, 5, 6, 7, 8, 9, 10]


### PR DESCRIPTION
This PR is prerequisite for https://github.com/nim-lang/Nim/pull/12407 where we changed hashing algorithm for integers to prevent multiple collisions happening in `HashSet` and `HashTable` with `int` keys.