### PR TITLE
make it compatible with new hashing

### DIFF
--- a/src/iterutils.nim
+++ b/src/iterutils.nim
@@ -318,4 +318,7 @@ when isMainModule:
     var s = newSeq[int]()
     for i in myiteropt(toClosure(values(d))): s.add(i)
     for i in myiteropt(toClosure(2..10)): s.add(i)
-    assert s == @[4, 5, 6, 4, 5, 6, 4, 5, 6, 2, 3, 4, 5, 6, 7, 8, 9, 10, 2, 3, 4, 5, 6, 7, 8, 9, 10, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    when NimVersion < "1.0.99":
+      assert s == @[4, 5, 6, 4, 5, 6, 4, 5, 6, 2, 3, 4, 5, 6, 7, 8, 9, 10, 2, 3, 4, 5, 6, 7, 8, 9, 10, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    else:
+      assert s == @[6, 4, 5, 6, 4, 5, 6, 4, 5, 2, 3, 4, 5, 6, 7, 8, 9, 10, 2, 3, 4, 5, 6, 7, 8, 9, 10, 2, 3, 4, 5, 6, 7, 8, 9, 10]


### PR DESCRIPTION
This is now the corrected version: the new hashing algo was slightly tweaked and it won't be part of Nim v1.0.2, so the modifications are needed only for devel (v1.0.99) and for future minor versions (v1.1, etc.).