### PR TITLE
supports Arc/Orc by enabling deepcopy

### DIFF
--- a/src/iterutils.nims
+++ b/src/iterutils.nims
@@ -1,0 +1,1 @@
+--deepcopy:on


### PR DESCRIPTION
Hello, the Nim v2 is going to default to orc. For --gc:arc|orc 'deepcopy' support has to be enabled with --deepcopy:on. 

ref https://github.com/nim-lang/Nim/pull/19972